### PR TITLE
Removed the unused prompt for the SDK version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,6 @@ name: Release Python SDK
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "The version of the Python SDK that you would like to release"
-        required: true
-        type: string
 
 jobs:
   release:


### PR DESCRIPTION
The SDK version is determined in the fern-config pipeline and stored in the repository files. This version is then used to publish the package to PyPI. The additional input is ignored.