### PR TITLE
Add Slack notifications for SDK publish workflows

### DIFF
--- a/.github/workflows/publish-layer.yml
+++ b/.github/workflows/publish-layer.yml
@@ -138,3 +138,22 @@ jobs:
             --layer-name "${LAYER_NAME}" \
             --max-items 1 \
             --region "${{ matrix.region }}"
+
+  notify-layer:
+    if: always()
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack - Lambda layer result
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_BUILD_WEBHOOK_URL }}
+          RESULT: ${{ needs.publish.result }}
+        run: |
+          if [ "$RESULT" = "success" ]; then
+            ICON=":white_check_mark:"; MSG="Python Lambda layer published (us-west-2, eu-west-1, ca-central-1)"
+          else
+            ICON=":x:"; MSG="Python Lambda layer publish failed"
+          fi
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\": \"${ICON} ${MSG} for v${{ inputs.sdk_version }}\"}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,42 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "SDK version: $VERSION"
 
+      - name: Notify Slack - Python SDK published
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_BUILD_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"text\": \":white_check_mark: Python SDK v${{ steps.get-version.outputs.version }} published to PyPI\",
+              \"blocks\": [{
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \":white_check_mark: *Python SDK Published to PyPI*\n*Version:* \`${{ steps.get-version.outputs.version }}\`\n*Package:* <https://pypi.org/project/samsara-api/${{ steps.get-version.outputs.version }}/|samsara-api>\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>\"
+                }
+              }]
+            }"
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_BUILD_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"text\": \":x: Python SDK publish to PyPI failed\",
+              \"blocks\": [{
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \":x: *Python SDK Publish Failed*\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>\"
+                }
+              }]
+            }"
+
   publish-layer:
     needs: release
     uses: ./.github/workflows/publish-layer.yml


### PR DESCRIPTION
Add Slack webhook notifications to `#alerts-api-sdk` for publish outcomes:

- **`publish.yml`**: Success/failure notification for PyPI publish
- **`publish-layer.yml`**: Success/failure notification for Lambda layer publish across 3 AWS regions

Uses `SLACK_SDK_BUILD_WEBHOOK_URL` secret (Slack Incoming Webhook). Notifications use `curl -s` so Slack failures never block the workflow.

Part of a set of PRs adding notifications across all 5 SDK repos.

Made with [Cursor](https://cursor.com)